### PR TITLE
Adding Bower installation support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# IDEs
+.idea/
+
+# package managers
+bower_components/
+node_modules/

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "angular-feature-toggle",
+  "version": "0.1.6",
+  "description": "feature toggling capabilities for angular",
+  "license": "ISC",
+  "main": "./src/angular-feature-toggle.js",
+  "dependencies": {
+    "angular": ">= 1.0.8"
+  },
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "package.json",
+    "dist",
+    "lib",
+    "config",
+    "example",
+    "test",
+    "Gruntfile.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:yairhaimo/angular-feature-toggle.git"
+  }
+}

--- a/dist/angular-feature-toggle.js
+++ b/dist/angular-feature-toggle.js
@@ -1,4 +1,4 @@
-(function() {
+(function(angular) {
   'use strict';
   angular.module('yh.featureToggle', ['semver'])
     .config(initFeatures)
@@ -180,7 +180,7 @@
     }
   }
   hideIfFeature.$inject = ['featureToggle'];
-})();
+})(window.angular);
 
 // semver
 (function() {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/yairhaimo/angular-feature-toggle.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yairhaimo/angular-feature-toggle.git"
   },
   "keywords": [
     "angular",
@@ -16,5 +16,8 @@
   ],
   "author": "yairhaimo",
   "license": "ISC",
-  "dependencies": {}
+  "dependencies": {},
+  "devDependencies": {
+    "bower": "^1.6.9"
+  }
 }

--- a/src/angular-feature-toggle.js
+++ b/src/angular-feature-toggle.js
@@ -1,4 +1,4 @@
-(function() {
+(function(angular) {
   'use strict';
   angular.module('yh.featureToggle', ['semver'])
     .config(initFeatures)
@@ -175,7 +175,7 @@
       }
     }
   }
-})();
+})(window.angular);
 
 // semver
 (function() {


### PR DESCRIPTION
Pull request adds [Bower](http://bower.io/) installation support: issue #4.  All that is required after merging the pull request is run `npm install` to install Bower, and then rung the following command:

```
bower register angular-feature-toggle git@github.com:yairhaimo/angular-feature-toggle.git
```

I have made one code change to inject 'angular' off the window object, this was grabbed from another Angular plug-in.  You might need to re-minify the code, as the magnification grunt tasks are not included.  Note, some other plug-in spin up a seperate repo just for bower: eg. _angular-feature-toggle-bower_.  They authors then keep that repo pretty flat, usually only including the un-minified source.

I have created a temp bower plug-in to unblock myself named 'angular-feature-toggle-hclark', which I will unregister as soon as you have an official version.
